### PR TITLE
Update Dockerfile for heapdump

### DIFF
--- a/task-manager/Dockerfile
+++ b/task-manager/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:17-jdk-alpine
 EXPOSE 8080
 COPY target/*.jar app.jar
-ENTRYPOINT ["java","-jar", "-Dserver.port=8080", "-Dspring.profiles.active=prod", "/app.jar"]
+ENTRYPOINT ["java","-jar", "-Dserver.port=8080", "-Dspring.profiles.active=prod", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/microservices/dump/", "/app.jar"]


### PR DESCRIPTION
capture out of memory error